### PR TITLE
Fix RO statement for /run/udev, add RO to /dev/disk

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -36,8 +36,8 @@ param_env_vars:
 param_usage_include_vols: true
 param_volumes:
   - { vol_path: "/config", vol_host_path: "<path to config>", desc: "Where config is stored." }
-  - { vol_path: "/dev/disk", vol_host_path: "/dev/disk", desc: "This is how Scrutiny accesses drives." }
-  - { vol_path: "/run/udev", vol_host_path: "/run/udev:ro", desc: "Provides necessary metadata to Scrutiny." }
+  - { vol_path: "/dev/disk:ro", vol_host_path: "/dev/disk", desc: "This is how Scrutiny accesses drives." }
+  - { vol_path: "/run/udev:ro", vol_host_path: "/run/udev", desc: "Provides necessary metadata to Scrutiny." }
 
 param_usage_include_ports: true
 param_ports:


### PR DESCRIPTION
RO was attached to the host path instead of the container, resulting in it outputting the wrong way around (`/run/udev:ro:/run/udev` instead of `/run/udev:/run/udev:ro`).

Add RO to `/dev/disk` as RW is not necessary.